### PR TITLE
ci: fix exit 126 by running bash build.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+text=auto eol=lf
+*.sh text eol=lf
+*.bash text eol=lf
+*.hook text eol=lf
+*.chroot text eol=lf
+*.png binary
+*.jpg binary
+*.ico binary
+*.gz binary
+*.xz binary

--- a/.github/workflows/iso.yml
+++ b/.github/workflows/iso.yml
@@ -11,7 +11,7 @@ jobs:
           sudo apt-get install -y live-build xorriso mtools
       - name: Build ISO
         run: |
-          ./build.sh
+          bash ./build.sh
       - name: Upload ISO artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- set executable bits on build scripts and configs to avoid permission errors
- call `bash ./build.sh` in GitHub Actions workflow
- enforce LF line endings via `.gitattributes`

## Testing
- `bash -n build.sh`


------
https://chatgpt.com/codex/tasks/task_e_689dfd3b16cc8332b8b4bcd1d43b8767